### PR TITLE
LineGraphSeries failed to allow OnTapHandler to be called on first data point

### DIFF
--- a/src/main/java/com/jjoe64/graphview/series/LineGraphSeries.java
+++ b/src/main/java/com/jjoe64/graphview/series/LineGraphSeries.java
@@ -475,6 +475,7 @@ public class LineGraphSeries<E extends DataPointInterface> extends BaseSeries<E>
                     paint.setStyle(Paint.Style.FILL);
                     canvas.drawCircle(first_X, first_Y, mStyles.dataPointsRadius, paint);
                     paint.setStyle(prevStyle);
+                    registerDataPoint(first_X, first_Y, value);
                 }
             }
             lastEndY = orgY;


### PR DESCRIPTION
First point was not being registered as a DataPoint and thus couldn't be clicked on.
Solves issue #537 
